### PR TITLE
Allow the forward declaration of GLEQevent in C++

### DIFF
--- a/gleq.h
+++ b/gleq.h
@@ -67,7 +67,7 @@ typedef enum
 
 } GLEQtype;
 
-typedef struct
+typedef struct GLEQevent
 {
     GLEQtype type;
     GLFWwindow* window;


### PR DESCRIPTION
Typedefs of unnamed structs cannot be forward declared. Giving a
name to the structs allows the forward declaration.
