### PR TITLE
Cast void pointers explicitly for C++ compatibility

### DIFF
--- a/gleq.h
+++ b/gleq.h
@@ -271,7 +271,7 @@ static void gleqFileDropCallback(GLFWwindow* window, int count, const char** pat
     GLEQevent* event = gleqNewEvent();
     event->type = GLEQ_FILE_DROPPED;
     event->window = window;
-    event->file.paths = malloc(count * sizeof(char*));
+    event->file.paths = (char**)malloc(count * sizeof(char*));
     event->file.count = count;
 
     while (count--)


### PR DESCRIPTION
Casting the result of the memory allocation to its destination type
(char **) will avoid the compiler (gcc) error.
