### PR TITLE
Fix compile error while minor ver < 3

### DIFF
--- a/test.c
+++ b/test.c
@@ -99,7 +99,7 @@ int main(int argc, char** argv)
                 case GLEQ_WINDOW_UNICONIFIED:
                     printf("Window uniconified\n");
                     break;
-
+#if GLFW_VERSION_MINOR >= 3
                 case GLEQ_WINDOW_MAXIMIZED:
                     printf("Window maximized\n");
                     break;
@@ -112,7 +112,7 @@ int main(int argc, char** argv)
                     printf("Window content scale %0.2fx%0.2f\n",
                            event.scale.x, event.scale.y);
                     break;
-
+#endif
                 case GLEQ_FRAMEBUFFER_RESIZED:
                     printf("Framebuffer resized to %ix%i\n",
                            event.size.width,


### PR DESCRIPTION
`GLEQ_WINDOW_MAXIMIZED`, `GLEQ_WINDOW_UNMAXIMIZED`, `GLEQ_WINDOW_SCALE_CHANGED` are supported only when minor version >= 3, thus while compiling `test.c` using `glfw3.2` error occurs. Besides current stable version of GLFW is 3.2 I think it's a bug.